### PR TITLE
fix: correct line-endings and permission in docker-build

### DIFF
--- a/AccountingService/accountingservice/Dockerfile
+++ b/AccountingService/accountingservice/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /app
 # copy source into the container with owner gradle
 COPY --chown=gradle:gradle . .
 
+# line endings and permissions when on windows machine
+RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
+
 # run the build without daemon
 RUN ./gradlew build --no-daemon
 

--- a/TermService/termservice/Dockerfile
+++ b/TermService/termservice/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /app
 # copy source into the container with owner gradle
 COPY --chown=gradle:gradle . .
 
+# line endings and permissions when on windows machine
+RUN sed -i 's/\r$//' gradlew && chmod +x gradlew
+
 # run the build without daemon
 RUN ./gradlew build --no-daemon
 


### PR DESCRIPTION
Incorrect line-endings of the gradlew-file when host-computer is windows caused bash not do detect it as a script and therefore not execute it.